### PR TITLE
Scale image as a percentage of terminal size

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -g, --gif <FILE>      Input animated gif filepath
-    -i, --image <FILE>    Input image filepath
+    -g, --gif <FILE>            Input animated gif filepath
+    -i, --image <FILE>          Input image filepath
+    -s, --scale <MULTIPLIER>    Scale width and height to a factor of terminal size
 ```
 
 ## Example output

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -28,19 +28,28 @@ fn main() {
                             .value_name("FILE")
                             .help("Input animated gif filepath")
                             .takes_value(true))
+                    .arg(Arg::with_name("scale")
+                            .short("s")
+                            .long("scale")
+                            .value_name("MULTIPLIER")
+                            .help("Scale width and height to a factor of terminal size")
+                            .takes_value(true))
                     .get_matches();
 
     let image_filepath = matches.value_of("image");
     let gif_filepath = matches.value_of("gif");
+    let scale = matches.value_of("scale")
+        .and_then(|x| x.parse::<f32>().ok())
+        .unwrap_or(1.0);
 
     let size = terminal_size();
 
     if let Some((Width(w), Height(h))) = size {
         if let Some(filepath) = image_filepath {
-            display_image(filepath, w as u32, h as u32);
+            display_image(filepath, (w as f32 * scale) as u32, (h as f32 * scale) as u32);
         } else if let Some(filepath) = gif_filepath {
             loop {
-                display_gif(filepath, w as u32, h as u32);
+                display_gif(filepath, (w as f32 * scale) as u32, (h as f32 * scale) as u32);
 
             }
         }


### PR DESCRIPTION
Examples:

    cargo run -- -i ferris.png -s 0.3 # print the image downscaled to 30% of terminal size
    cargo run -- --gif pika.gif --scale 0.5 # play the gif downscaled to half terminal size

If the argument is ommited, then a default value of 1.0 is used, making the command work as before this change.